### PR TITLE
Remove appsfor non admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Each script does slighly different steps in places, for either the INTEL or ARM(
 - microsoft-azure-storage-explorer
 - R (only for full admin macs. non admin users should get from MoJ Self Service store)
 - rstudio
-- visual-studio
 - visual-studio-code
+-#visual-studio (no longer installed - user is advised to use the free version which is visual-studio-code)
 - slack
 - pgadmin4
 - parallels (only for INTEL based Macbooks)
@@ -75,6 +75,7 @@ Each script does slighly different steps in places, for either the INTEL or ARM(
 - R (only for full admin macs. non admin users should get from MoJ Self Service store)
 - rstudio
 - visual-studio-code
+-#visual-studio (no longer installed - user is advised to use the free version which is visual-studio-code)
 - slack
 - pgadmin4
 - parallels (only for INTEL based Macbooks)

--- a/README.md
+++ b/README.md
@@ -11,10 +11,14 @@ Choose the correct script for your particular Macbook. It may have Intel chipset
 
 Note: The scripts for the Non Admin Macs do exactly the same installs except that Casks are installed into ~/Applications folder rather than /Applications folder
 
-To run the script, use the simple following one-liner in the terminal
+To run the script (for full Admin macbooks), use the simple following one-liner in the terminal
 
 `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/hmcts/macbook-software/master/setup<INTEL|ARM>.sh)"`
  
+To run the script (for NonAdmin macbooks), use the simple following one-liner in the terminal
+
+`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/hmcts/macbook-software/master/setup<INTEL|ARM>forNonAdminMacs.sh)"`
+
 Alternatively, enter the following into the terminal (requires Git to be installed):
  
 - Create folder called Projects `mkdir Projects`
@@ -24,7 +28,7 @@ Alternatively, enter the following into the terminal (requires Git to be install
 - Clone the repo to download the files % `git clone https://github.com/hmcts/macbook-software`
 - Navigate to the macbook-software folder % `cd macbook-software`
 - Make it executable % `chmod +x setup*.sh`
-- Run the script % `./setup<INTEL|ARM>.sh`
+- Run the relevant setup.sh script for your platform and whether you have Admin or not
  
 As the script runs it will prompt several times for admin password to proceed with an install. The admin password is the one you use to login to the Macbook, not your Apple ID password.
 
@@ -43,11 +47,11 @@ Each script does slighly different steps in places, for either the INTEL or ARM(
 - yq
 - adoptopenjdk
 - intellij-idea
-- docker
+- docker (only for full admin macs. non admin users should get from MoJ Self Service store)
 - pycharm
 - azure-data-studio
 - microsoft-azure-storage-explorer
-- R
+- R (only for full admin macs. non admin users should get from MoJ Self Service store)
 - rstudio
 - visual-studio
 - visual-studio-code
@@ -64,11 +68,11 @@ Each script does slighly different steps in places, for either the INTEL or ARM(
 - postgresql
 - python3
 - azure-cli
-- docker
+- docker (only for full admin macs. non admin users should get from MoJ Self Service store)
 - pycharm
 - azure-data-studio
 - microsoft-azure-storage-explorer
-- R
+- R (only for full admin macs. non admin users should get from MoJ Self Service store)
 - rstudio
 - visual-studio-code
 - slack
@@ -85,7 +89,7 @@ Each script does slighly different steps in places, for either the INTEL or ARM(
 - python3
 - azure-cli
 - yq
-- docker
+- docker (only for full admin macs. non admin users should get from MoJ Self Service store)
 - adoptopenjdk
 - intellij-idea
 - pycharm

--- a/setupARMforNonAdminMacs.sh
+++ b/setupARMforNonAdminMacs.sh
@@ -30,7 +30,7 @@ developers(){
 
     #now install casks
     CASKS=(
-        docker
+        #docker Needs password so better installed via MoJ Self service store
         adoptopenjdk
         intellij-idea
         pycharm
@@ -40,7 +40,7 @@ developers(){
     )
     # Same Casks, but a Seperate list for uninstall casks, as the order may need to be different
     CASKS_UNINSTALL=(
-        docker
+        #docker Needs password so better installed via MoJ Self service store
         adoptopenjdk
         intellij-idea
         pycharm
@@ -83,11 +83,11 @@ dataengineers(){
     
     #now install casks
     CASKS=(
-        docker
+        #docker Needs password so better installed via MoJ Self service store
         pycharm
         azure-data-studio
         microsoft-azure-storage-explorer
-        R
+        #R Needs password so better installed via MoJ Self service store
         rstudio
     #    visual-studio
         visual-studio-code
@@ -98,11 +98,11 @@ dataengineers(){
     )
     # Same Casks, but a Seperate list for uninstall casks, as the order may need to be different
     CASKS_UNINSTALL=(
-        docker
+        #docker Needs password so better installed via MoJ Self service store
         pycharm
         azure-data-studio
         microsoft-azure-storage-explorer
-        R
+        #R Needs password so better installed via MoJ Self service store
         rstudio
     #    visual-studio
         visual-studio-code
@@ -152,11 +152,11 @@ allsoftware(){
         CASKS=(
             adoptopenjdk
             intellij-idea
-            docker
+            #docker Needs password so better installed via MoJ Self service store
             pycharm
             azure-data-studio
             microsoft-azure-storage-explorer
-            R
+            #R Needs password so better installed via MoJ Self service store
             rstudio
             visual-studio
             visual-studio-code
@@ -169,11 +169,11 @@ allsoftware(){
         CASKS_UNINSTALL=(
             adoptopenjdk #password may be necessary
             intellij-idea
-            docker #password alwyas seems to be required
+            #docker Needs password so better installed via MoJ Self service store
             pycharm
             azure-data-studio
             microsoft-azure-storage-explorer
-            R #password may be necessary
+            #R Needs password so better installed via MoJ Self service store
             rstudio
             visual-studio
             visual-studio-code
@@ -254,11 +254,11 @@ determine_mac_arch(){
         # This script is to setup ARM Macbooks Check if the ARCH is correct. If not, then exit the script and ask the user to run the correct script.
         if [ "$ARCH" = "arm" ]
         then
-           echo "You are using the correct setup script for this type of Macbook. setupARM.sh" 
+           echo "You are using the correct setup script for this type of Macbook. setupARMforNonAdminMacs.sh" 
         else
            echo "WARNING!!!!! This script is only for Macbooks with the ARM(M1/M2) chipsets."
            echo "You are NOT using the correct setup script for this type of Macbook. This script is only for Macbooks with the ARM(M1/M2) chipisets"
-           echo "We will exit the script now. Please try and run the correct setupINTEL.sh script for your chipset"
+           echo "We will exit the script now. Please try and run the correct setupINTELforNonAdminMacs.sh script for your chipset"
            echo "EXITING NOW.."
            exit 1
         fi
@@ -308,6 +308,7 @@ clear
 # Version 0.7 - Rajiv Kapoor (minor changes. More specific changes to detect between M2 and Intel especially re: parallels installation)
 # Version 0.8 - Rajiv Kapoor (Made this file now and going forward just for installation on ARM(M1/M2) based chipsets)
 # Version 0.9 - Rajiv Kapoor (Made this specific file now for Non Admin Macbooks.It uses the --appdir flag when installing Casks 
+# Version 1.0 - Rajiv Kapoor (No longer installs Docker and R, as these should be installed via SelfServiceStore or another way 
 
 cat << "EOF"
  _   _ ___  ________ _____ _____   _____________
@@ -327,6 +328,7 @@ echo ""
 echo "Any problems email :"
 echo "Thomas Geraghty - thomas.geraghty@justice.gov.uk for DTS Developer/QA queries"
 echo "Alexander Gudgeon - alexander.gudgeon@justice.gov.uk for A&P Data Engineering queries"
+echo "Rajiv Kapoor - rajiv.kapoor@justice.gov.uk for general queries on this script"
 echo ""
 determine_mac_arch
 
@@ -336,7 +338,7 @@ select opt in "${options[@]}"
 do
     case $opt in
         "Install DTS Developer Tools")
-            echo "you chose to install tools for $opt - $REPLY"
+            echo "you chose to install tools for $opt - $REPLa"
             MODE=install
             install_homebrew
             developers

--- a/setupARMforNonAdminMacs.sh
+++ b/setupARMforNonAdminMacs.sh
@@ -158,7 +158,7 @@ allsoftware(){
             microsoft-azure-storage-explorer
             #R Needs password so better installed via MoJ Self service store
             rstudio
-            visual-studio
+            #visual-studio
             visual-studio-code
         #    virtualbox
             slack
@@ -175,7 +175,7 @@ allsoftware(){
             microsoft-azure-storage-explorer
             #R Needs password so better installed via MoJ Self service store
             rstudio
-            visual-studio
+            #visual-studio
             visual-studio-code
         #    virtualbox
             slack
@@ -308,7 +308,7 @@ clear
 # Version 0.7 - Rajiv Kapoor (minor changes. More specific changes to detect between M2 and Intel especially re: parallels installation)
 # Version 0.8 - Rajiv Kapoor (Made this file now and going forward just for installation on ARM(M1/M2) based chipsets)
 # Version 0.9 - Rajiv Kapoor (Made this specific file now for Non Admin Macbooks.It uses the --appdir flag when installing Casks 
-# Version 1.0 - Rajiv Kapoor (No longer installs Docker and R, as these should be installed via SelfServiceStore or another way 
+# Version 1.0 - Rajiv Kapoor (No longer installs Docker and R,VSStudio, as these should be installed via SelfServiceStore or another way 
 
 cat << "EOF"
  _   _ ___  ________ _____ _____   _____________

--- a/setupINTELforNonAdminMacs.sh
+++ b/setupINTELforNonAdminMacs.sh
@@ -158,7 +158,7 @@ allsoftware(){
             microsoft-azure-storage-explorer
             #R Needs password so better installed via MoJ Self service store
             rstudio
-            visual-studio
+            #visual-studio
             visual-studio-code
         #    virtualbox
             slack
@@ -175,7 +175,7 @@ allsoftware(){
             microsoft-azure-storage-explorer
             #R Needs password so better installed via MoJ Self service store
             rstudio
-            visual-studio
+            #visual-studio
             visual-studio-code
         #    virtualbox
             slack
@@ -337,7 +337,7 @@ clear
 # Version 0.7 - Rajiv Kapoor (minor changes. More specific changes to detect between M2 and Intel especially re: parallels installation)
 # Version 0.8 - Rajiv Kapoor (Made this file now and going forward just for installation on Intel based chipsets)
 # Version 0.9 - Rajiv Kapoor (Made this specific file now for Non Admin Macbooks.It uses the --appdir flag when installing Casks
-# Version 1.0 - Rajiv Kapoor (No longer installs Docker and R, as these should be installed via SelfServiceStore or another way 
+# Version 1.0 - Rajiv Kapoor (No longer installs Docker and R,VS Studio as these should be installed via SelfServiceStore or another way 
 
 
 cat << "EOF"

--- a/setupINTELforNonAdminMacs.sh
+++ b/setupINTELforNonAdminMacs.sh
@@ -30,7 +30,7 @@ developers(){
 
     #now install casks
     CASKS=(
-        docker
+        #docker Needs password so better installed via MoJ Self service store
         adoptopenjdk
         intellij-idea
         pycharm
@@ -40,7 +40,7 @@ developers(){
     )
     # Same Casks, but a Seperate list for uninstall casks, as the order may need to be different
     CASKS_UNINSTALL=(
-        docker
+        #docker Needs password so better installed via MoJ Self service store
         adoptopenjdk
         intellij-idea
         pycharm
@@ -83,11 +83,11 @@ dataengineers(){
     
     #now install casks
     CASKS=(
-        docker
+        #docker Needs password so better installed via MoJ Self service store
         pycharm
         azure-data-studio
         microsoft-azure-storage-explorer
-        R
+        #R Needs password so better installed via MoJ Self service store
         rstudio
     #    visual-studio
         visual-studio-code
@@ -98,11 +98,11 @@ dataengineers(){
     )
     # Same Casks, but a Seperate list for uninstall casks, as the order may need to be different
     CASKS_UNINSTALL=(
-        docker
+        #docker Needs password so better installed via MoJ Self service store
         pycharm
         azure-data-studio
         microsoft-azure-storage-explorer
-        R
+        #R Needs password so better installed via MoJ Self service store
         rstudio
     #    visual-studio
         visual-studio-code
@@ -152,11 +152,11 @@ allsoftware(){
         CASKS=(
             adoptopenjdk
             intellij-idea
-            docker
+            #docker Needs password so better installed via MoJ Self service store
             pycharm
             azure-data-studio
             microsoft-azure-storage-explorer
-            R
+            #R Needs password so better installed via MoJ Self service store
             rstudio
             visual-studio
             visual-studio-code
@@ -169,11 +169,11 @@ allsoftware(){
         CASKS_UNINSTALL=(
             adoptopenjdk #password may be necessary
             intellij-idea
-            docker #password alwyas seems to be required
+            #docker Needs password so better installed via MoJ Self service store
             pycharm
             azure-data-studio
             microsoft-azure-storage-explorer
-            R #password may be necessary
+            #R Needs password so better installed via MoJ Self service store
             rstudio
             visual-studio
             visual-studio-code
@@ -301,11 +301,11 @@ determine_mac_arch(){
         then
            echo "WARNING!!!!! This script is only for Macbooks with the Intel chip."
            echo "You are NOT using the correct setup script for this type of Macbook. This script is only for Macbooks with the Intel chip."
-           echo "We will exit the script now. Please try and run the correct setupARM.sh script for your chipset"
+           echo "We will exit the script now. Please try and run the correct setupARMforNonAdminMacs.sh script for your chipset"
            echo "EXITING NOW.."
            exit 1
         fi
-        echo "You are using the correct setup script for this type of Macbook. setupINTEL.sh" 
+        echo "You are using the correct setup script for this type of Macbook. setupINTELforNonAdminMacs.sh" 
 }
 
  # Install homebrew if not already installed
@@ -337,6 +337,7 @@ clear
 # Version 0.7 - Rajiv Kapoor (minor changes. More specific changes to detect between M2 and Intel especially re: parallels installation)
 # Version 0.8 - Rajiv Kapoor (Made this file now and going forward just for installation on Intel based chipsets)
 # Version 0.9 - Rajiv Kapoor (Made this specific file now for Non Admin Macbooks.It uses the --appdir flag when installing Casks
+# Version 1.0 - Rajiv Kapoor (No longer installs Docker and R, as these should be installed via SelfServiceStore or another way 
 
 
 cat << "EOF"


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSSE-6065

### Change description

Realised that nonAdmin scripts do not work with installing Docker, and R. So i removed these from their installs (they can get these apps from the self service store instead). I updated README too. Plus an overhand was that I also commented out the install of visual-studi, as the free version, visual-studio-code would be better

### Testing done
done by me
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x ] commit messages are meaningful and follow good commit message guidelines
- [x ] README and other documentation has been updated / added (if needed)
- [no ] Does this PR introduce a breaking change
